### PR TITLE
fix: Prevent array OOB in resume() and make leader selection

### DIFF
--- a/handover/HANDOVER.md
+++ b/handover/HANDOVER.md
@@ -1,0 +1,318 @@
+# Handover Document: Commit-Reveal2 Security Review
+
+**Repository:** `tokamak-network/Commit-Reveal2`  
+**Branch:** `fix/leader-selection`  
+**Date:** February 21, 2026  
+**Primary File Reviewed:** `src/CommitReveal2WithLeaderSelection.sol`
+
+---
+
+## 1. Scope of Review
+
+The review primarily focused on `src/CommitReveal2WithLeaderSelection.sol` (835 lines), the main contract implementing the Commit-Reveal² decentralized random number generation protocol with an embedded leader selection mechanism. The full inheritance chain was examined for context:
+
+| File | Lines | Role |
+|------|-------|------|
+| `src/CommitReveal2WithLeaderSelection.sol` | ~835 | **Primary review target** — request, submit, generate, refund, resume |
+| `src/LeaderSelection.sol` | ~109 | Leader election commit-reveal mini-protocol |
+| `src/FailLogics.sol` | ~808 | Failure handlers with slashing |
+| `src/DisputeLogics.sol` | ~1037 | Dispute mechanism (requestCv, submitCv, requestCo, submitCo, requestS, submitS) |
+| `src/OperatorManager.sol` | ~411 | Operator lifecycle: deposit, activate, deactivate, withdraw |
+| `src/CommitReveal2Storage.sol` | ~517 | Storage layout, structs, errors, events, constants |
+
+**Total:** ~3,712 lines of Solidity (majority inline Yul assembly)
+
+### Out of Scope
+
+The following files were not the focus of this review (but were glanced at for completeness):
+
+- `src/CommitReveal2BLS.sol` — BLS signature variant (uses `onlyOwner` resume, no leader election)
+- `src/CommitReveal2.sol` — Base variant without leader selection
+- `src/CommitReveal2L2.sol` — L2-specific variant
+- `src/libraries/BLS.sol`, `src/libraries/Bitmap.sol` — Library code
+- `src/governance/` — Governance multisig wallet
+- `src/test/` — Test contracts and utilities
+
+---
+
+## 2. Architecture Overview
+
+### Inheritance Chain
+
+```
+CommitReveal2WithLeaderSelection
+└── LeaderSelection
+    └── FailLogics
+        └── DisputeLogics
+            ├── EIP712 (OpenZeppelin — signature verification)
+            ├── OperatorManager
+            │   └── Ownable (Solady)
+            └── CommitReveal2Storage
+```
+
+### Protocol Flow
+
+1. **Consumer** calls `requestRandomNumber()`, paying a fee.
+2. **Leader** (owner) collects operator secrets off-chain, builds a Merkle tree, submits root via `submitMerkleRoot()`.
+3. **Leader** calls `generateRandomNumber()` with all secrets and signatures — produces a verifiable random number delivered via callback.
+4. **Dispute path:** If the leader misbehaves or times out, operators trigger failure functions. These slash the responsible party, halt the system, and initiate leader selection.
+5. **Leader selection:** A commit-reveal mini-protocol among operators produces election randomness. The operator whose `hash(electionRandomness || address)` is smallest becomes the new leader.
+6. **Resume:** `resume()` finalizes the election, transfers ownership, and restarts the pending round.
+
+### State Machine
+
+```
+COMPLETED (2)  ──requestRandomNumber()──>  IN_PROGRESS (1)
+IN_PROGRESS (1) ──generateRandomNumber()──> COMPLETED (2)  [if no more rounds]
+IN_PROGRESS (1) ──fail*()──────────────────> HALTED (3)
+HALTED (3)      ──resume()─────────────────> IN_PROGRESS (1) or COMPLETED (2)
+```
+
+---
+
+## 3. Code Changes Made
+
+### Fix: H-01 — Liveness Risk in `resume()`
+
+**Problem:** When the system enters HALTED, operators are expected to participate in the leader selection commit-reveal. If no operator commits or reveals, `resume()` would either:
+- Revert with an out-of-bounds array access, or
+- Proceed with empty/deterministic randomness, selecting a predictable leader
+
+Both outcomes could leave the system permanently stuck.
+
+**Changes applied:**
+
+**`src/LeaderSelection.sol`** — Added two new error declarations:
+
+```solidity
+error LeaderSelectionNotInitiated(); // 0x5251b3cf
+error NoRevealsForLeaderSelection(); // 0x7ffd6dc1
+```
+
+**`src/CommitReveal2WithLeaderSelection.sol`** — Added guard checks at the top of `resume()`:
+
+```solidity
+function resume() external payable {
+    if (s_cvsForLeaderSelection.length == 0) revert LeaderSelectionNotInitiated();
+    if (s_revealForLeaderSelection.length == 0) revert NoRevealsForLeaderSelection();
+    if (block.timestamp < s_leaderSelectionTime) revert CannotResumeBeforeLeaderSelectionTime();
+    // ... rest of function
+}
+```
+
+**Rationale:** This ensures `resume()` cleanly reverts if no operator participated in leader selection, preventing both the OOB crash and the degenerate case of selecting a leader from empty randomness.
+
+---
+
+## 4. Key Observation: CV Computation Discrepancy (Paper vs Code)
+
+The academic paper specifies:
+
+```
+cv_i = Hash(co_i)
+```
+
+The code computes:
+
+```
+cv_i = Hash(co_i ∥ index)
+```
+
+where `index` is a single byte representing the operator's position. This is a **strictly stronger construction** — it prevents cross-operator collision when two operators coincidentally share the same secret value. This does not weaken any security property and is actually an improvement. However, the paper should be updated to reflect this for accuracy (Section IV or VII).
+
+---
+
+## 5. Findings Summary
+
+A full security audit was conducted. The findings table below reflects the current status:
+
+| ID | Severity | Title | Status |
+|----|----------|-------|--------|
+| H-01 | HIGH | Liveness risk: `resume()` reverts if no operator reveals during leader selection | **Fixed** |
+| H-02 | HIGH | `nextRequestedRound` loop capped at 10 iterations — state may become inconsistent | Open |
+| M-01 | MEDIUM | `setPeriods()` permits changes during HALTED, inconsistent with other setters | Open |
+| M-02 | MEDIUM | `resume()` does not reset stale leader-selection timestamps | Open |
+| M-03 | MEDIUM | O(n²) gas cost in `resume()` from `abi.encodePacked` in loop | Open |
+| M-04 | MEDIUM | No zero-address validation for governance multisig in constructor | Open |
+| M-05 | MEDIUM | Governance multisig address is immutable with no rotation mechanism | Open |
+| M-06 | MEDIUM | Leader selection commit/reveal durations hardcoded to 60 seconds | Open |
+| M-07 | MEDIUM | No input validation on `setPeriods()` parameters | Open |
+| I-01 | INFO | Duplicated `leastSignificantBit` / `nextRequestedRound` across 4 locations | — |
+| I-02 | INFO | Pervasive inline assembly impedes auditability | — |
+| I-03 | INFO | No NatSpec documentation on `CommitReveal2WithLeaderSelection` functions | — |
+| I-04 | INFO | `setGasParameters` mixes assembly storage writes with Solidity `emit` | — |
+| I-05 | GAS | `resume()` leader election loop uses Solidity-level storage reads where assembly could be cheaper | — |
+| I-06 | GAS | `s_merkleRoot` is a single slot overwritten each round — previous roots are lost | — |
+
+The full detailed audit report is available at [`docs/AUDIT_REPORT.md`](../docs/AUDIT_REPORT.md).
+
+---
+
+## 6. Test Coverage for Findings
+
+Each finding requires proper test coverage before or alongside its fix. The table below maps every finding to the test cases that are needed.
+
+### Existing Tests
+
+The following test files already exist in the repo:
+
+| Test File | Covers |
+|-----------|--------|
+| `test/unit/ResumeDeactivationBug.t.sol` | `resume()` backward-iteration deactivation (7 test cases: 3-of-6, 4-of-7, all-revealed, one-non-revealer, first-operators, alternating, large-scale-32) |
+| `test/unit/SimpleTransferOwnership.t.sol` | Ownership transfer basics |
+| `test/unit/ParamDelay.t.sol` | Parameter delay logic |
+| `test/staging/CommitReveal2Flowchart.t.sol` | Full protocol flow (happy path + dispute) |
+| `test/gas/*.t.sol` | Gas benchmarks for all major paths |
+| `test/fuzz/CreateMerkleRootFuzz.t.sol` | Fuzz testing for Merkle root creation |
+
+### Required Test Cases per Finding
+
+#### H-01 — Liveness risk in `resume()` (Fixed)
+
+| # | Test Case | Status | Description |
+|---|-----------|--------|-------------|
+| 1 | `test_resume_revertsWhenNoCommits` | **Needed** | Call `resume()` in HALTED state without any operator calling `commit()`. Must revert with `LeaderSelectionNotInitiated()`. |
+| 2 | `test_resume_revertsWhenCommitsButNoReveals` | **Needed** | Operators call `commit()` but nobody calls `reveal()`. Must revert with `NoRevealsForLeaderSelection()`. |
+| 3 | `test_resume_succeedsWhenAtLeastOneReveals` | **Exists** | Covered by `ResumeDeactivationBug.t.sol` — multiple scenarios with partial reveals. |
+
+#### H-02 — `nextRequestedRound` loop capped at 10 iterations (Open)
+
+| # | Test Case | Status | Description |
+|---|-----------|--------|-------------|
+| 4 | `test_nextRequestedRound_gapExceeds2550` | **Needed** | Request round 0 and round 3000 (gap > 2550). Call `generateRandomNumber()` for round 0. Verify state transitions correctly to round 3000 or falls back to `COMPLETED`. |
+| 5 | `test_nextRequestedRound_exactlyAtBoundary` | **Needed** | Request rounds such that the next round is exactly at 2550 apart (10 * 255). Verify the loop finds it. |
+| 6 | `test_nextRequestedRound_gapInResume` | **Needed** | Same gap scenario but exercised through `resume()` after a HALTED state. |
+
+#### M-01 — `setPeriods()` allows changes during HALTED (Open)
+
+| # | Test Case | Status | Description |
+|---|-----------|--------|-------------|
+| 7 | `test_setPeriods_revertsWhenHalted` | **Needed** | Enter HALTED state, call `setPeriods()` from governance. Verify it reverts (after fix) or document that it succeeds (if intentional). |
+| 8 | `test_setPeriods_succeedsWhenCompleted` | **Needed** | In COMPLETED state, call `setPeriods()` from governance. Verify it succeeds. |
+
+#### M-02 — `resume()` does not reset stale timestamps (Open)
+
+| # | Test Case | Status | Description |
+|---|-----------|--------|-------------|
+| 9 | `test_resume_resetsLeaderSelectionTimestamps` | **Needed** | Complete a full halt-election-resume cycle. Verify `s_leaderSelectionTime` and `s_revealStartTimeForLeaderSelection` are reset to 0 after `resume()`. |
+| 10 | `test_resume_staleTimestampDoesNotBypassCheck` | **Needed** | After first resume cycle, trigger a second halt. Call `resume()` before any new commit/reveal. Must revert (not pass because of stale timestamp). |
+
+#### M-03 — O(n²) gas cost in `resume()` (Open)
+
+| # | Test Case | Status | Description |
+|---|-----------|--------|-------------|
+| 11 | `test_resume_gasWithMaxOperators` | **Exists (partial)** | `ResumeDeactivationBug.t.sol::test_resume_largeScale_halfDidNotReveal` runs with 32 operators. Extend to capture gas metrics before/after optimization. |
+
+#### M-04 — No zero-address validation for governance multisig (Open)
+
+| # | Test Case | Status | Description |
+|---|-----------|--------|-------------|
+| 12 | `test_constructor_revertsOnZeroGovernance` | **Needed** | Deploy with `address(0)` as governance. Must revert after fix. |
+
+#### M-05 — Governance multisig is immutable (Open)
+
+| # | Test Case | Status | Description |
+|---|-----------|--------|-------------|
+| 13 | `test_setGovernanceMultisig_succeeds` | **Needed** | Call governance rotation function from current governance. Verify address updates. |
+| 14 | `test_setGovernanceMultisig_revertsFromNonGovernance` | **Needed** | Call governance rotation from a non-governance address. Must revert. |
+
+#### M-06 — Leader selection durations hardcoded (Open)
+
+| # | Test Case | Status | Description |
+|---|-----------|--------|-------------|
+| 15 | `test_leaderSelection_customDurations` | **Needed** | Deploy with custom commit/reveal durations. Verify commit phase respects the custom duration. |
+
+#### M-07 — No input validation on `setPeriods()` (Open)
+
+| # | Test Case | Status | Description |
+|---|-----------|--------|-------------|
+| 16 | `test_setPeriods_revertsOnZeroValues` | **Needed** | Call `setPeriods()` with one or more periods set to 0. Must revert after fix. |
+| 17 | `test_setPeriods_revertsOnUnreasonablySmall` | **Needed** | Call `setPeriods()` with values below `MIN_PERIOD`. Must revert after fix. |
+
+### Test Case Summary
+
+| Category | Existing | Needed | Total |
+|----------|----------|--------|-------|
+| H-01 (Fixed) | 6 | 2 | 8 |
+| H-02 | 0 | 3 | 3 |
+| M-01 | 0 | 2 | 2 |
+| M-02 | 0 | 2 | 2 |
+| M-03 | 1 (partial) | 0 | 1 |
+| M-04 | 0 | 1 | 1 |
+| M-05 | 0 | 2 | 2 |
+| M-06 | 0 | 1 | 1 |
+| M-07 | 0 | 2 | 2 |
+| **Total** | **7** | **15** | **22** |
+
+> **Important:** Every open finding must have its corresponding test case(s) written and passing **before** the fix is considered complete. Write the test first to reproduce the issue (expect failure or wrong behavior), apply the fix, then verify the test passes.
+
+---
+
+## 7. Priority Items for Next Steps
+
+### Critical / High Priority
+
+1. **H-02 (Open):** The `nextRequestedRound` bitmap search loop is capped at 10 iterations. If a gap exceeds ~2,550 un-requested rounds, the state machine can become inconsistent. Add a fallback after the loop that sets state to `COMPLETED`.
+
+2. **M-02 (Open):** `resume()` deletes the leader-selection arrays but does not reset `s_revealStartTimeForLeaderSelection` or `s_leaderSelectionTime`. Stale timestamps from a previous election can cause subtle timing issues if the system halts again. The fix is two lines:
+
+```solidity
+s_revealStartTimeForLeaderSelection = 0;
+s_leaderSelectionTime = 0;
+```
+
+### Medium Priority
+
+3. **M-03:** Replace the O(n²) `abi.encodePacked` loop in `resume()` with a pre-allocated buffer.
+4. **M-04:** Add `require(_governanceMultisig != address(0))` in the constructor.
+5. **M-05:** Add a governance transfer function with two-step acceptance.
+6. **M-06:** Make leader selection commit/reveal durations configurable.
+7. **M-07:** Add minimum-value validation for `setPeriods()` parameters.
+8. **M-01:** Change `setPeriods()` modifier from `notInProgress` to `onlyWhenCompleted`.
+
+---
+
+## 8. Positive Observations
+
+- **Checks-Effects-Interactions pattern** followed throughout — ETH transfers happen after state changes.
+- **Signature malleability prevention** via `s <= SECP256K1_CURVE_ORDER` check.
+- **Bitmap-based round tracking** for gas-efficient request management.
+- **Slash reward accumulator pattern** (reward-per-token style) for O(1) distribution.
+- **EIP-150 gas accounting** for consumer callbacks prevents griefing.
+- **Free memory pointer discipline** in all assembly blocks.
+- **Reverse iteration** in `resume()` deactivation loop handles swap-and-pop safely.
+
+---
+
+## 9. Build & Test
+
+```bash
+# Install dependencies
+forge install
+
+# Build
+forge build
+
+# Run all tests
+forge test
+
+# Run resume deactivation tests
+forge test --match-contract ResumeDeactivationBug -vvvv
+
+# Run a specific test with gas reporting
+forge test --match-test test_resume_largeScale_halfDidNotReveal -vvvv --gas-report
+```
+
+---
+
+## 10. Files Modified in This Review
+
+| File | Change |
+|------|--------|
+| `src/CommitReveal2WithLeaderSelection.sol` | Added `LeaderSelectionNotInitiated` and `NoRevealsForLeaderSelection` guards to `resume()` |
+| `src/LeaderSelection.sol` | Added two new error declarations |
+| `docs/AUDIT_REPORT.md` | Created full security audit report, updated finding statuses |
+
+---
+
+*End of Handover Document*

--- a/src/CommitReveal2WithLeaderSelection.sol
+++ b/src/CommitReveal2WithLeaderSelection.sol
@@ -654,6 +654,8 @@ contract CommitReveal2WithLeaderSelection is LeaderSelection {
     }
 
     function resume() external payable {
+        if (s_cvsForLeaderSelection.length == 0) revert LeaderSelectionNotInitiated();
+        if (s_revealForLeaderSelection.length == 0) revert NoRevealsForLeaderSelection();
         if (block.timestamp < s_leaderSelectionTime) revert CannotResumeBeforeLeaderSelectionTime();
         uint256 activatedOperatorsLength = s_activatedOperators.length;
         uint256 revealLength = s_revealForLeaderSelection.length;

--- a/src/CommitReveal2WithLeaderSelection.sol
+++ b/src/CommitReveal2WithLeaderSelection.sol
@@ -656,23 +656,44 @@ contract CommitReveal2WithLeaderSelection is LeaderSelection {
     function resume() external payable {
         if (block.timestamp < s_leaderSelectionTime) revert CannotResumeBeforeLeaderSelectionTime();
         uint256 activatedOperatorsLength = s_activatedOperators.length;
-        for (uint256 i; i < activatedOperatorsLength; ++i) {
+        // Iterate backwards to avoid array out-of-bounds when _deactivate
+        // swap-and-pops elements, shrinking the array during iteration.
+        for (uint256 i = activatedOperatorsLength; i > 0;) {
+            unchecked {
+                --i;
+            }
             if (s_revealForLeaderSelection[i] == 0) {
                 address addressToDeactivate = s_activatedOperators[i];
-                _deactivate(s_activatedOperatorIndex1Based[s_activatedOperators[i]] - 1, addressToDeactivate);
+                _deactivate(i, addressToDeactivate);
                 _settleSlashReward(addressToDeactivate);
             }
         }
         activatedOperatorsLength = s_activatedOperators.length; // new length after deactivations
-        // argmin_i Hash(R_elec || addr_i)
-        bytes32 elecRandomness = keccak256(abi.encodePacked(s_revealForLeaderSelection));
+        // Build election randomness from only non-zero revealed values.
+        // Including zeros from non-revealers makes the hash predictable and manipulable.
+        uint256 revealArrayLength = s_revealForLeaderSelection.length;
+        bytes memory revealedValues;
+        for (uint256 i; i < revealArrayLength;) {
+            uint256 val = s_revealForLeaderSelection[i];
+            if (val != 0) {
+                revealedValues = abi.encodePacked(revealedValues, val);
+            }
+            unchecked {
+                ++i;
+            }
+        }
+        // argmin_i Hash(R_elec || addr_i) — order-independent leader selection
+        bytes32 elecRandomness = keccak256(revealedValues);
         uint256 minHash = type(uint256).max;
         uint256 indexForLeader;
-        for (uint256 i; i < activatedOperatorsLength; ++i) {
+        for (uint256 i; i < activatedOperatorsLength;) {
             uint256 h = uint256(keccak256(abi.encodePacked(elecRandomness, s_activatedOperators[i])));
             if (h < minHash) {
                 minHash = h;
                 indexForLeader = i;
+            }
+            unchecked {
+                ++i;
             }
         }
         _settleSlashReward(owner());

--- a/src/CommitReveal2WithLeaderSelection.sol
+++ b/src/CommitReveal2WithLeaderSelection.sol
@@ -656,13 +656,14 @@ contract CommitReveal2WithLeaderSelection is LeaderSelection {
     function resume() external payable {
         if (block.timestamp < s_leaderSelectionTime) revert CannotResumeBeforeLeaderSelectionTime();
         uint256 activatedOperatorsLength = s_activatedOperators.length;
+        uint256 revealLength = s_revealForLeaderSelection.length;
         // Iterate backwards to avoid array out-of-bounds when _deactivate
         // swap-and-pops elements, shrinking the array during iteration.
         for (uint256 i = activatedOperatorsLength; i > 0;) {
             unchecked {
                 --i;
             }
-            if (s_revealForLeaderSelection[i] == 0) {
+            if (i < revealLength && s_revealForLeaderSelection[i] == 0) {
                 address addressToDeactivate = s_activatedOperators[i];
                 _deactivate(i, addressToDeactivate);
                 _settleSlashReward(addressToDeactivate);

--- a/src/LeaderSelection.sol
+++ b/src/LeaderSelection.sol
@@ -19,6 +19,8 @@ contract LeaderSelection is FailLogics {
     error RevealPhaseOver();
     error AlreadyRevealed();
     error NotCommitted();
+    error LeaderSelectionNotInitiated(); // 0x5251b3cf
+    error NoRevealsForLeaderSelection(); // 0x7ffd6dc1
 
     constructor(
         uint256 commitDurationForLeaderSelection_,

--- a/test/unit/ResumeDeactivationBug.t.sol
+++ b/test/unit/ResumeDeactivationBug.t.sol
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test, console2} from "forge-std/Test.sol";
+import {CommitReveal2WithLeaderSelection} from "../../src/CommitReveal2WithLeaderSelection.sol";
+import {ConsumerExample} from "../../src/ConsumerExample.sol";
+
+/**
+ * @title ResumeDeactivationBugTest
+ * @notice Tests for the bug in resume() where forward-iterating over s_activatedOperators
+ *         while calling _deactivate (swap-and-pop) causes array out-of-bounds errors
+ *         when multiple operators need to be deactivated.
+ *
+ * Bug scenario (with old forward-iteration code):
+ *   - 6 activated operators at indices [0..5], operators[3,4,5] didn't reveal
+ *   - Loop caches original length = 6
+ *   - i=3: deactivate op3. _deactivate swaps op3 with op5, pops. Array length = 5
+ *   - i=4: deactivate op4. _deactivate pops op4. Array length = 4
+ *   - i=5: s_activatedOperators[5] => OUT OF BOUNDS! Array only has 4 elements.
+ *
+ * Fix: Iterate backwards so _deactivate's swap-and-pop never affects unvisited indices.
+ */
+contract ResumeDeactivationBugTest is Test {
+    CommitReveal2WithLeaderSelection public commitReveal2;
+    ConsumerExample public consumerExample;
+
+    address constant LEADER = address(0xBcd4042DE499D14e55001CcbB24a551F3b954096);
+    address constant GOVERNANCE = address(0xdead);
+
+    uint256 constant ACTIVATION_THRESHOLD = 0.01 ether;
+    uint256 constant FLAT_FEE = 0.001 ether;
+    uint256 constant MAX_GAS_PRICE = 15 gwei;
+
+    // Timing parameters
+    uint256 constant OFF_CHAIN_SUBMISSION_PERIOD = 40;
+    uint256 constant REQUEST_OR_SUBMIT_OR_FAIL_DECISION_PERIOD = 30;
+    uint256 constant ON_CHAIN_SUBMISSION_PERIOD = 60;
+    uint256 constant OFF_CHAIN_SUBMISSION_PERIOD_PER_OPERATOR = 20;
+    uint256 constant ON_CHAIN_SUBMISSION_PERIOD_PER_OPERATOR = 30;
+
+    // Leader selection timing (hardcoded in constructor: 60s commit, 60s reveal)
+    uint256 constant COMMIT_DURATION = 60;
+    uint256 constant REVEAL_DURATION = 60;
+
+    address[] public operators;
+    uint256[] public operatorKeys;
+    uint256 public numOperators;
+
+    function setUp() public {
+        vm.deal(LEADER, 10000 ether);
+        vm.deal(GOVERNANCE, 1 ether);
+    }
+
+    /// @dev Deploy contracts and set up a given number of operators
+    function _setupWithOperators(uint256 count) internal {
+        numOperators = count;
+
+        // Deploy CommitReveal2WithLeaderSelection as LEADER
+        vm.startPrank(LEADER);
+        commitReveal2 = new CommitReveal2WithLeaderSelection{value: ACTIVATION_THRESHOLD}(
+            ACTIVATION_THRESHOLD,
+            FLAT_FEE,
+            "Commit Reveal2",
+            "1",
+            OFF_CHAIN_SUBMISSION_PERIOD,
+            REQUEST_OR_SUBMIT_OR_FAIL_DECISION_PERIOD,
+            ON_CHAIN_SUBMISSION_PERIOD,
+            OFF_CHAIN_SUBMISSION_PERIOD_PER_OPERATOR,
+            ON_CHAIN_SUBMISSION_PERIOD_PER_OPERATOR,
+            MAX_GAS_PRICE,
+            GOVERNANCE
+        );
+        vm.stopPrank();
+
+        // Deploy ConsumerExample
+        consumerExample = new ConsumerExample(address(commitReveal2));
+
+        // Create and fund operators
+        for (uint256 i = 0; i < count; i++) {
+            (address addr, uint256 key) = makeAddrAndKey(string(abi.encodePacked("op", i)));
+            operators.push(addr);
+            operatorKeys.push(key);
+            vm.deal(addr, 10000 ether);
+        }
+
+        // Activate all operators
+        for (uint256 i = 0; i < count; i++) {
+            vm.prank(operators[i]);
+            commitReveal2.depositAndActivate{value: ACTIVATION_THRESHOLD}();
+        }
+
+        assertEq(commitReveal2.getActivatedOperatorsLength(), count);
+    }
+
+    /// @dev Advance time
+    function _mine(uint256 seconds_) internal {
+        vm.warp(block.timestamp + seconds_);
+        vm.roll(block.number + 1);
+    }
+
+    /// @dev Get the contract into HALTED state
+    function _getIntoHaltedState() internal {
+        vm.txGasPrice(10 gwei);
+        uint256 requestFee = commitReveal2.estimateRequestPrice(90000, tx.gasprice);
+        vm.deal(address(this), requestFee);
+        consumerExample.requestRandomNumber{value: requestFee}();
+
+        _mine(OFF_CHAIN_SUBMISSION_PERIOD + REQUEST_OR_SUBMIT_OR_FAIL_DECISION_PERIOD);
+        commitReveal2.failToRequestSubmitCvOrSubmitMerkleRoot();
+
+        assertEq(commitReveal2.s_isInProcess(), 3, "Should be HALTED");
+    }
+
+    /// @dev Have specified operators commit and reveal; the rest do not participate
+    /// @param revealingIndices Array of indices into the `operators` array for operators that commit+reveal
+    function _commitAndReveal(uint256[] memory revealingIndices) internal {
+        // Build commit values
+        uint256[] memory secrets = new uint256[](revealingIndices.length);
+        uint256[] memory revealValues = new uint256[](revealingIndices.length);
+        uint256[] memory cvs = new uint256[](revealingIndices.length);
+
+        for (uint256 i = 0; i < revealingIndices.length; i++) {
+            secrets[i] = 1000 + revealingIndices[i];
+            revealValues[i] = uint256(keccak256(abi.encodePacked(secrets[i])));
+            cvs[i] = uint256(keccak256(abi.encodePacked(revealValues[i])));
+        }
+
+        // Commit phase
+        for (uint256 i = 0; i < revealingIndices.length; i++) {
+            vm.prank(operators[revealingIndices[i]]);
+            commitReveal2.commit(cvs[i]);
+        }
+
+        // Wait for commit phase to end
+        _mine(COMMIT_DURATION);
+
+        // Reveal phase
+        for (uint256 i = 0; i < revealingIndices.length; i++) {
+            vm.prank(operators[revealingIndices[i]]);
+            commitReveal2.reveal(revealValues[i]);
+        }
+
+        // Wait for reveal phase to end
+        _mine(REVEAL_DURATION);
+
+        assertTrue(block.timestamp >= commitReveal2.s_leaderSelectionTime(), "Past leader selection time");
+    }
+
+    /// @dev Call resume and verify basic invariants
+    function _callResume() internal {
+        address caller = makeAddr("resumeCaller");
+        vm.deal(caller, 10 ether);
+        vm.prank(caller);
+        commitReveal2.resume{value: ACTIVATION_THRESHOLD}();
+    }
+
+    // =========================================================================
+    //                              TEST CASES
+    // =========================================================================
+
+    /**
+     * @notice Core bug test: 3 out of 6 operators didn't reveal.
+     *
+     * With the OLD forward-iteration code, this would revert:
+     *   - Cached length = 6
+     *   - Deactivate at i=3: array shrinks to 5
+     *   - Deactivate at i=4: array shrinks to 4
+     *   - Access s_activatedOperators[5] at i=5 => OUT OF BOUNDS
+     *
+     * After fix (backward iteration): works correctly.
+     * Final state: 6 - 3(non-revealers) - 1(new leader) = 2 operators remain.
+     */
+    function test_resume_multipleDeactivations_3of6() public {
+        _setupWithOperators(6);
+        _getIntoHaltedState();
+
+        // Only operators[0], [1], [2] reveal; operators[3], [4], [5] do NOT
+        uint256[] memory revealers = new uint256[](3);
+        revealers[0] = 0;
+        revealers[1] = 1;
+        revealers[2] = 2;
+        _commitAndReveal(revealers);
+
+        _callResume();
+
+        // Verify non-revealers are deactivated
+        assertEq(commitReveal2.s_activatedOperatorIndex1Based(operators[3]), 0, "Op3 deactivated");
+        assertEq(commitReveal2.s_activatedOperatorIndex1Based(operators[4]), 0, "Op4 deactivated");
+        assertEq(commitReveal2.s_activatedOperatorIndex1Based(operators[5]), 0, "Op5 deactivated");
+
+        // New owner should be one of the revealers
+        address newOwner = commitReveal2.owner();
+        assertTrue(
+            newOwner == operators[0] || newOwner == operators[1] || newOwner == operators[2],
+            "New owner from revealers"
+        );
+    }
+
+    /**
+     * @notice 4 out of 7 operators didn't reveal — more severe case.
+     *
+     * Forward iteration would fail even earlier:
+     *   - After 3 deactivations, array length is 4 but loop tries index 4,5,6
+     *
+     * After fix: 7 - 4 - 1(leader) = 2 operators remain.
+     */
+    function test_resume_multipleDeactivations_4of7() public {
+        _setupWithOperators(7);
+        _getIntoHaltedState();
+
+        // Only operators[0], [1], [2] reveal; [3..6] do NOT
+        uint256[] memory revealers = new uint256[](3);
+        revealers[0] = 0;
+        revealers[1] = 1;
+        revealers[2] = 2;
+        _commitAndReveal(revealers);
+
+        _callResume();
+
+        // Verify all non-revealers deactivated
+        for (uint256 i = 3; i < 7; i++) {
+            assertEq(commitReveal2.s_activatedOperatorIndex1Based(operators[i]), 0);
+        }
+    }
+
+    /**
+     * @notice All operators reveal — no deactivations needed (happy path).
+     */
+    function test_resume_allRevealed_noDeactivations() public {
+        _setupWithOperators(5);
+        _getIntoHaltedState();
+
+        uint256[] memory revealers = new uint256[](5);
+        for (uint256 i = 0; i < 5; i++) {
+            revealers[i] = i;
+        }
+        _commitAndReveal(revealers);
+
+        _callResume();
+
+        // New owner is one of the operators
+        address newOwner = commitReveal2.owner();
+        bool isOp = false;
+        for (uint256 i = 0; i < 5; i++) {
+            if (newOwner == operators[i]) {
+                isOp = true;
+                break;
+            }
+        }
+        assertTrue(isOp, "New owner from operators");
+    }
+
+    /**
+     * @notice Only 1 operator didn't reveal — minimal deactivation.
+     * 5 operators - 1 non-revealer - 1 leader = 3 remain.
+     */
+    function test_resume_oneNonRevealer() public {
+        _setupWithOperators(5);
+        _getIntoHaltedState();
+
+        // operators[0..3] reveal, operator[4] does NOT
+        uint256[] memory revealers = new uint256[](4);
+        for (uint256 i = 0; i < 4; i++) {
+            revealers[i] = i;
+        }
+        _commitAndReveal(revealers);
+
+        _callResume();
+
+        assertEq(commitReveal2.s_activatedOperatorIndex1Based(operators[4]), 0, "Op4 deactivated");
+    }
+
+    /**
+     * @notice First operators in array didn't reveal.
+     *
+     * operators[0], [1] do NOT reveal; [2..5] DO reveal.
+     * 6 - 2 - 1(leader) = 3 remain.
+     *
+     * This tests the backward iteration when early indices are removed
+     * (with forward iteration, the swap-and-pop would move later operators
+     * into early positions, corrupting the index-reveal mapping).
+     */
+    function test_resume_firstOperatorsDidNotReveal() public {
+        _setupWithOperators(6);
+        _getIntoHaltedState();
+
+        // operators[2..5] reveal; [0],[1] do NOT
+        uint256[] memory revealers = new uint256[](4);
+        revealers[0] = 2;
+        revealers[1] = 3;
+        revealers[2] = 4;
+        revealers[3] = 5;
+        _commitAndReveal(revealers);
+
+        _callResume();
+
+        assertEq(commitReveal2.s_activatedOperatorIndex1Based(operators[0]), 0, "Op0 deactivated");
+        assertEq(commitReveal2.s_activatedOperatorIndex1Based(operators[1]), 0, "Op1 deactivated");
+
+        address newOwner = commitReveal2.owner();
+        assertTrue(
+            newOwner == operators[2] || newOwner == operators[3]
+                || newOwner == operators[4] || newOwner == operators[5],
+            "New owner from revealers"
+        );
+    }
+
+    /**
+     * @notice Alternating pattern: operators at even indices don't reveal.
+     *
+     * 7 operators. [0], [2], [4], [6] do NOT reveal (4 non-revealers).
+     * [1], [3], [5] DO reveal.
+     * 7 - 4 - 1(leader) = 2 remain.
+     *
+     * This is the worst case for forward iteration: scattered deactivations
+     * cause maximum index corruption.
+     */
+    function test_resume_alternatingNonRevealers() public {
+        _setupWithOperators(7);
+        _getIntoHaltedState();
+
+        // Only operators[1], [3], [5] reveal
+        uint256[] memory revealers = new uint256[](3);
+        revealers[0] = 1;
+        revealers[1] = 3;
+        revealers[2] = 5;
+        _commitAndReveal(revealers);
+
+        _callResume();
+
+        // Even-indexed operators deactivated
+        assertEq(commitReveal2.s_activatedOperatorIndex1Based(operators[0]), 0, "Op0 deactivated");
+        assertEq(commitReveal2.s_activatedOperatorIndex1Based(operators[2]), 0, "Op2 deactivated");
+        assertEq(commitReveal2.s_activatedOperatorIndex1Based(operators[4]), 0, "Op4 deactivated");
+        assertEq(commitReveal2.s_activatedOperatorIndex1Based(operators[6]), 0, "Op6 deactivated");
+
+        address newOwner = commitReveal2.owner();
+        assertTrue(
+            newOwner == operators[1] || newOwner == operators[3] || newOwner == operators[5],
+            "New owner from revealers"
+        );
+    }
+
+    /**
+     * @notice Stress test with maximum operators (32), half don't reveal.
+     *
+     * 32 operators. 16 don't reveal. 32 - 16 - 1(leader) = 15 remain.
+     * With forward iteration this would be completely broken.
+     */
+    function test_resume_largeScale_halfDidNotReveal() public {
+        _setupWithOperators(32);
+        _getIntoHaltedState();
+
+        // Even-indexed operators reveal (16 out of 32)
+        uint256[] memory revealers = new uint256[](16);
+        for (uint256 i = 0; i < 16; i++) {
+            revealers[i] = i * 2; // 0, 2, 4, 6, ..., 30
+        }
+        _commitAndReveal(revealers);
+
+        _callResume();
+
+        // Odd-indexed operators should be deactivated
+        for (uint256 i = 0; i < 16; i++) {
+            assertEq(
+                commitReveal2.s_activatedOperatorIndex1Based(operators[i * 2 + 1]),
+                0,
+                "Odd operator should be deactivated"
+            );
+        }
+    }
+}


### PR DESCRIPTION

- Iterate backwards when deactivating non-revealers to avoid out-of-bounds access caused by _deactivate's swap-and-pop shrinking the array mid-loop
- Pass index directly to _deactivate instead of redundant index lookup
- Build election randomness from only non-zero revealed values, excluding zeros from non-revealers that made the hash predictable and manipulable
- Add comprehensive tests for multi-deactivation scenarios